### PR TITLE
Cache bookdown files to avoid regenerating imgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: R
 sudo: false
-cache: packages
+cache:
+  packages: true
+  directories:
+  - "$TRAVIS_BUILD_DIR/_bookdown_files"
 env:
   global:
     secure: jYrXpSL/uqWMitKaQebFLYYRUjocoCTu9FpIBgaULAnAeGpJ6O9gtjq199OzDxCgRdYrUDs3upLeQIFNkHq6LqHdMcl2RLMSH9iyyRRLxQCie1VnSAN9yekbTxB09xfzx/4o5zMfRl+H6zJxRnkdrHBK7rKaV6vIzv0GfIbHF/Jeek1IINvi08Qc2Fe/CwEKqeIUfsDxosxWUHM58DvYsQCGhgTRzdT0YjDVM/0l1f3Xlf/qdMpzP1iA+fmGwBNTchtF/9fb7/XRhtlG0JQ0IQmXUUryOExIJW2w40Awns8qB0tToktdoTTtDjXt5tZ3Jhv2w+2YHQ7oqp4Ehv+FUCxj94njQrjfiBZQGnwAlXUXas36YQpntC38Y23NiI+wqJSOXvqF1OxsqSDcAY+ws80xRsELe6iGr66NJF2MyyMBMM4sZ3M5L9ieF1SNh87aqyom3CLkfGPgRRNeRzLpZO7fLHfOeoKOtU30ovE4pq73FqSrIx+3+xsoIKIYabNm7CSHfuHQvLvjXRKCL50sFyfRum/ANLBOpIvddwNW6CaItPpEwbzoTHSRVilbVDZd9ZpWwFHgBUFYfAN+HGFbViambjxZ9+BlaHmfFLskrvMBh7d+TmsatGdZknuZ7k7WaQMkNBsnaDRh3Cv1pEL7enC9/Lw+eGVKBsr3HZtzUWk=


### PR DESCRIPTION
Need to destroy the `gh-pages` and create a new orphan branch as well... This will stop the churn though.
