### PR TITLE
Fixes #12 Link Targets

### DIFF
--- a/anova.Rmd
+++ b/anova.Rmd
@@ -35,7 +35,7 @@ The biggest difference between an observational study and an experiment is *how*
 
 In an experiment, the predictors, which are controlled by the experimenter, are called **factors**. The possible values of these factors are called **levels**. Subjects are *randomly* assigned to a level of each of the factors.
 
-The design of experiments could be a course by itself. The Wikipedia article on [design of experiments](https://en.wikipedia.org/wiki/Design_of_experiments) gives a good overview. Originally, most of the methodology was developed for agricultural applications by [R. A. Fisher](https://en.wikipedia.org/wiki/Ronald_Fisher), but are still in use today, now in a wide variety of application areas. Notably, these methods have seen a resurgence as a part of "A/B Testing."
+The design of experiments could be a course by itself. The Wikipedia article on [design of experiments](https://en.wikipedia.org/wiki/Design_of_experiments){target="_blank"} gives a good overview. Originally, most of the methodology was developed for agricultural applications by [R. A. Fisher](https://en.wikipedia.org/wiki/Ronald_Fisher){target="_blank"}, but are still in use today, now in a wide variety of application areas. Notably, these methods have seen a resurgence as a part of "A/B Testing."
 
 <!-- TODO: In the future, discuss the Morrow Plots: http://cropsci.illinois.edu/research/morrow -->
 
@@ -92,7 +92,7 @@ melatonin = data.frame(
 )
 ```
 
-As an example, suppose we are interested in the effect of [melatotin](https://en.wikipedia.org/wiki/Melatonin) on sleep duration. A researcher obtains a random sample of 20 adult males. Of these subjects, 10 are randomly chosen for the control group, which will receive a placebo. The remaining 10 will be given 5mg of melatonin before bed. The sleep duration in hours of each subject is then measured. The researcher chooses a significance level of $\alpha = 0.10$. Was sleep duration affected by the melatonin?
+As an example, suppose we are interested in the effect of [melatotin](https://en.wikipedia.org/wiki/Melatonin){target="_blank"} on sleep duration. A researcher obtains a random sample of 20 adult males. Of these subjects, 10 are randomly chosen for the control group, which will receive a placebo. The remaining 10 will be given 5mg of melatonin before bed. The sleep duration in hours of each subject is then measured. The researcher chooses a significance level of $\alpha = 0.10$. Was sleep duration affected by the melatonin?
 
 ```{r}
 melatonin
@@ -496,9 +496,9 @@ Notice the `pairwise.t.test()` function does not have a `data` argument. To avoi
 
 Also note that we are using the argument `p.adj = "none"`. What is this? An adjustment (in this case not an adjustment) to the p-value of each test. Why would we need to do this?
 
-The adjustment is an attempt to correct for the [multiple testing problem](https://en.wikipedia.org/wiki/Multiple_comparisons_problem). (See also: [Relevant XKCD](https://xkcd.com/882/). ) Imagine that you knew ahead of time that you were going to perform 100 $t$-tests. Suppose you wish to do this with a false positive rate of $\alpha = 0.05$. If we use this significance level for each test, for 100 tests, we then expect 5 false positives. That means, with 100 tests, we're almost guaranteed to have at least one error.
+The adjustment is an attempt to correct for the [multiple testing problem](https://en.wikipedia.org/wiki/Multiple_comparisons_problem){target="_blank"}. (See also: [Relevant XKCD](https://xkcd.com/882/){target="_blank"}. ) Imagine that you knew ahead of time that you were going to perform 100 $t$-tests. Suppose you wish to do this with a false positive rate of $\alpha = 0.05$. If we use this significance level for each test, for 100 tests, we then expect 5 false positives. That means, with 100 tests, we're almost guaranteed to have at least one error.
 
-What we'd really like, is for the [family-wise error rate](https://en.wikipedia.org/wiki/Family-wise_error_rate) to be 0.05. If we consider the 100 tests to be a single "experiment" the FWER is the rate of one or more false positives for in the full experiment (100 tests). Consider it an error rate for an entire procedure, instead of a single test.
+What we'd really like, is for the [family-wise error rate](https://en.wikipedia.org/wiki/Family-wise_error_rate){target="_blank"} to be 0.05. If we consider the 100 tests to be a single "experiment" the FWER is the rate of one or more false positives for in the full experiment (100 tests). Consider it an error rate for an entire procedure, instead of a single test.
 
 With this in mind, one of the simplest adjustments we can make, is to increase the p-values for each test, depending on the number of tests. In particular the Bonferroni correction simply multiplies by the number of tests.
 
@@ -539,7 +539,7 @@ mean(replicate(1000, any(replicate(100, get_p_val()) < 0.05)))
 mean(replicate(1000, any(p.adjust(replicate(100, get_p_val()), "bonferroni") < 0.05)))
 ```
 
-For the specific case of testing all two-way mean differences after an ANOVA test, there are [a number of potential methods](https://en.wikipedia.org/wiki/Post_hoc_analysis) for making an adjustment of this type. The pros and cons of the potential methods are beyond the scope of this course. We choose a method for its ease of use, and to a lesser extent, its developer.
+For the specific case of testing all two-way mean differences after an ANOVA test, there are [a number of potential methods](https://en.wikipedia.org/wiki/Post_hoc_analysis){target="_blank"} for making an adjustment of this type. The pros and cons of the potential methods are beyond the scope of this course. We choose a method for its ease of use, and to a lesser extent, its developer.
 
 Tukey's Honest Significance difference can be applied directly to an object which was created using `aov()`. It will adjust the p-values of the pairwise comparisons of the means to control the FWER, in this case, for 0.05. Notice it also gives confidence intervals for the difference of the means.
 
@@ -555,7 +555,7 @@ Also, nicely, we can easily produce a plot of these confidence intervals.
 plot(TukeyHSD(coag_aov, conf.level = 0.95))
 ```
 
-The creator of this method, [John Tukey](https://en.wikipedia.org/wiki/John_Tukey), is an important figure in the history of data science. He essentially [predicted the rise of data science over 50 years ago](https://projecteuclid.org/euclid.aoms/1177704711). For some retrospective thoughts on those 50 years, see [this paper from David Donoho](http://courses.csail.mit.edu/18.337/2015/docs/50YearsDataScience.pdf).
+The creator of this method, [John Tukey](https://en.wikipedia.org/wiki/John_Tukey){target="_blank"}, is an important figure in the history of data science. He essentially [predicted the rise of data science over 50 years ago](https://projecteuclid.org/euclid.aoms/1177704711){target="_blank"}. For some retrospective thoughts on those 50 years, see [this paper from David Donoho](http://courses.csail.mit.edu/18.337/2015/docs/50YearsDataScience.pdf){target="_blank"}.
 
 ## Two-Way ANOVA
 

--- a/beyond.Rmd
+++ b/beyond.Rmd
@@ -14,37 +14,37 @@ So you've completed STAT 420, where do you go from here? Now that you understand
 
 ## RStudio
 
-RStudio has recently released version 1.0! This is exciting for a number of reason, especially the release of [`R` Notebooks](http://rmarkdown.rstudio.com/r_notebooks.html). `R` Notebooks combine the RMarkdown you have already learned with the ability to work interactively.
+RStudio has recently released version 1.0! This is exciting for a number of reason, especially the release of [`R` Notebooks](http://rmarkdown.rstudio.com/r_notebooks.html){target="_blank"}. `R` Notebooks combine the RMarkdown you have already learned with the ability to work interactively.
 
 ## Tidy Data
 
-In this textbook, much of the data we have seen has been nice and tidy. It was rectangular where each row is an observation and each column is a variable. This is not always the case! Many packages have been developed to deal with data, and force it into a nice format, which is called [tidy data](http://vita.had.co.nz/papers/tidy-data.pdf), that we can then use for modeling. Often during analysis, this is where a large portion of your time will be spent.
+In this textbook, much of the data we have seen has been nice and tidy. It was rectangular where each row is an observation and each column is a variable. This is not always the case! Many packages have been developed to deal with data, and force it into a nice format, which is called [tidy data](http://vita.had.co.nz/papers/tidy-data.pdf){target="_blank"}, that we can then use for modeling. Often during analysis, this is where a large portion of your time will be spent.
 
-The `R` community has started to call this collection of packages the [Tidyverse](http://tidyverse.org/). It was once called the Hadleyverse, as [Hadley Wickham](http://hadley.nz/) has authored so many of the packages. Hadley is writing a book called [`R` for Data Science](http://r4ds.had.co.nz/) which describes the use of many of these packages. (And also how to use some to make the modeling process better!) This book is a great starting point for diving deeper into the `R` community. The two main packages are [`dplyr`](https://cran.r-project.org/web/packages/dplyr/vignettes/dplyr.html) and [`tidyr`](https://blog.rstudio.org/2014/07/22/introducing-tidyr/) both of which are used internally in RStudio.
+The `R` community has started to call this collection of packages the [Tidyverse](http://tidyverse.org/){target="_blank"}. It was once called the Hadleyverse, as [Hadley Wickham](http://hadley.nz/){target="_blank"} has authored so many of the packages. Hadley is writing a book called [`R` for Data Science](http://r4ds.had.co.nz/){target="_blank"} which describes the use of many of these packages. (And also how to use some to make the modeling process better!) This book is a great starting point for diving deeper into the `R` community. The two main packages are [`dplyr`](https://cran.r-project.org/web/packages/dplyr/vignettes/dplyr.html){target="_blank"} and [`tidyr`](https://blog.rstudio.org/2014/07/22/introducing-tidyr/){target="_blank"} both of which are used internally in RStudio.
 
 ## Visualization
 
-In this course, we have mostly used the base plotting methods in `R`. When working with tidy data, many users prefer to use the [`ggplot2`](http://ggplot2.org/) package, also developed by Hadley Wickham. RStudio provides a rather detailed ["cheat sheet"](https://www.rstudio.com/wp-content/uploads/2015/03/ggplot2-cheatsheet.pdf) for working with `ggplot2`. The community maintains a [graph gallery](http://www.r-graph-gallery.com/portfolio/ggplot2-package/) of examples.
+In this course, we have mostly used the base plotting methods in `R`. When working with tidy data, many users prefer to use the [`ggplot2`](http://ggplot2.org/){target="_blank"} package, also developed by Hadley Wickham. RStudio provides a rather detailed ["cheat sheet"](https://www.rstudio.com/wp-content/uploads/2015/03/ggplot2-cheatsheet.pdf){target="_blank"} for working with `ggplot2`. The community maintains a [graph gallery](http://www.r-graph-gallery.com/portfolio/ggplot2-package/){target="_blank"} of examples.
 
-Use of the [`manipulate` package](https://support.rstudio.com/hc/en-us/articles/200551906-Interactive-Plotting-with-Manipulate) with RStudio gives the ability to quickly change a static graphic to become interactive.
+Use of the [`manipulate` package](https://support.rstudio.com/hc/en-us/articles/200551906-Interactive-Plotting-with-Manipulate){target="_blank"} with RStudio gives the ability to quickly change a static graphic to become interactive.
 
 ## Web Applications
 
-RStudio has made it incredible easy to create data products through the use of [Shiny](https://shiny.rstudio.com/), which allows for the creation of web applications with `R`. RStudio maintains an ever-growing [tutorial](http://shiny.rstudio.com/tutorial/) and [gallery](https://shiny.rstudio.com/gallery/) of examples.
+RStudio has made it incredible easy to create data products through the use of [Shiny](https://shiny.rstudio.com/){target="_blank"}, which allows for the creation of web applications with `R`. RStudio maintains an ever-growing [tutorial](http://shiny.rstudio.com/tutorial/){target="_blank"} and [gallery](https://shiny.rstudio.com/gallery/){target="_blank"} of examples.
 
 ## Experimental Design
 
-In the ANOVA chapter, we briefly discussed experimental design. This topic could easily be its own class, and is currently an area of revitalized interest with the rise of [A/B testing.](https://en.wikipedia.org/wiki/A/B_testing) Two more classic statistical references include *Statistics for Experimenters* by Box, Hunter, and Hunter as well as *Design and Analysis of Experiments* by Douglas Montgomery. There are several `R` packages for design of experiments, list in the [CRAN Task View](https://cran.r-project.org/web/views/ExperimentalDesign.html).
+In the ANOVA chapter, we briefly discussed experimental design. This topic could easily be its own class, and is currently an area of revitalized interest with the rise of [A/B testing.](https://en.wikipedia.org/wiki/A/B_testing){target="_blank"} Two more classic statistical references include *Statistics for Experimenters* by Box, Hunter, and Hunter as well as *Design and Analysis of Experiments* by Douglas Montgomery. There are several `R` packages for design of experiments, list in the [CRAN Task View](https://cran.r-project.org/web/views/ExperimentalDesign.html){target="_blank"}.
 
 ## Machine Learning
 
-Using models for prediction is the key focus of machine learning. There are many methods, each with its own package, however `R` has a wonderful package called [`caret`, *Classification And REgression Training*,](http://topepo.github.io/caret/index.html) which provides a unified interface to training these models. It also contains various utilities for data processing and visualization that are useful for predictive modeling. 
+Using models for prediction is the key focus of machine learning. There are many methods, each with its own package, however `R` has a wonderful package called [`caret`, *Classification And REgression Training*,](http://topepo.github.io/caret/index.html){target="_blank"} which provides a unified interface to training these models. It also contains various utilities for data processing and visualization that are useful for predictive modeling. 
 
-*Applied Predictive Modeling* by Max Kuhn, the author of the `caret` package is a good general resource for predictive modeling, which obviously utilizes `R`. [*An Introduction to Statistical Learning*](http://www-bcf.usc.edu/~gareth/ISL/) by James, Witten, Hastie, and Tibshirani is a gentle introduction to machine learning from a statistical perspective which uses `R` and picks up right where this courses stops. This is based on the often referenced [*The Elements of Statistical Learning*](https://web.stanford.edu/~hastie/Papers/ESLII.pdf) by Hastie, Tibshirani, and Friedman. Both are freely available online.
+*Applied Predictive Modeling* by Max Kuhn, the author of the `caret` package is a good general resource for predictive modeling, which obviously utilizes `R`. [*An Introduction to Statistical Learning*](http://www-bcf.usc.edu/~gareth/ISL/){target="_blank"} by James, Witten, Hastie, and Tibshirani is a gentle introduction to machine learning from a statistical perspective which uses `R` and picks up right where this courses stops. This is based on the often referenced [*The Elements of Statistical Learning*](https://web.stanford.edu/~hastie/Papers/ESLII.pdf){target="_blank"} by Hastie, Tibshirani, and Friedman. Both are freely available online.
 
 ### Deep Learning
 
-While, it probably isn't the best tool for the job, `R` now has the ability to [train deep neural networks via TensorFlow](https://rstudio.github.io/tensorflow/).
+While, it probably isn't the best tool for the job, `R` now has the ability to [train deep neural networks via TensorFlow](https://rstudio.github.io/tensorflow/){target="_blank"}.
 
 ## Time Series
 
@@ -52,30 +52,30 @@ In this class we have only considered independent data. What if data is dependen
 
 Two books that are used in STAT 429 at the University of Illinois, both free:
 
-- [*Time Series Analysis and Its Applications: With R Examples*](http://www.stat.pitt.edu/stoffer/tsa4/) by Shumway and Stoffer
-- [A Tour of Time Series Analysis with R](http://tts.smac-group.com/) by Balamuta, Guerrier, Molinari, and Xu. This book is currently under development at UIUC.
+- [*Time Series Analysis and Its Applications: With R Examples*](http://www.stat.pitt.edu/stoffer/tsa4/){target="_blank"} by Shumway and Stoffer
+- [A Tour of Time Series Analysis with R](http://tts.smac-group.com/){target="_blank"} by Balamuta, Guerrier, Molinari, and Xu. This book is currently under development at UIUC.
 
 Some tutorials:
 
-- [Little Book of R for Time Series](https://a-little-book-of-r-for-time-series.readthedocs.io/en/latest/)
-- [Quick `R`: Time Series and Forecasting](http://www.statmethods.net/advstats/timeseries.html)
-- [TSA: Start to Finish Examples](http://rpubs.com/ryankelly/ts6)
+- [Little Book of R for Time Series](https://a-little-book-of-r-for-time-series.readthedocs.io/en/latest/){target="_blank"}
+- [Quick `R`: Time Series and Forecasting](http://www.statmethods.net/advstats/timeseries.html){target="_blank"}
+- [TSA: Start to Finish Examples](http://rpubs.com/ryankelly/ts6){target="_blank"}
 
-When performing time series analysis in `R` you should be aware of the [many packages](https://cran.r-project.org/web/views/TimeSeries.html) that are useful for analysis. It should be hard to avoid the [`forecast`](https://github.com/robjhyndman/forecast) and [`zoo`](https://cran.r-project.org/web/packages/zoo/zoo.pdf) packages. Often the most difficult part will be dealing with time and date data. Make sure you are utilizing one of the many packages that help with this.
+When performing time series analysis in `R` you should be aware of the [many packages](https://cran.r-project.org/web/views/TimeSeries.html){target="_blank"} that are useful for analysis. It should be hard to avoid the [`forecast`](https://github.com/robjhyndman/forecast){target="_blank"} and [`zoo`](https://cran.r-project.org/web/packages/zoo/zoo.pdf){target="_blank"} packages. Often the most difficult part will be dealing with time and date data. Make sure you are utilizing one of the many packages that help with this.
 
 ## Bayesianism
 
 In this class, we have worked within the frequentist view of statistics. There is an entire alternative universe of Bayesian statistics.
 
-[*Doing Bayesian Data Analysis: A Tutorial with R, JAGS, and Stan*](https://sites.google.com/site/doingbayesiandataanalysis/) by John Kruschke is a great introduction to the topic. It introduces the world of [probabilistic programming](https://www.cs.cornell.edu/Courses/cs4110/2016fa/lectures/lecture33.html), in particular [Stan](http://mc-stan.org/), which can be used in both `R` and Python.
+[*Doing Bayesian Data Analysis: A Tutorial with R, JAGS, and Stan*](https://sites.google.com/site/doingbayesiandataanalysis/){target="_blank"} by John Kruschke is a great introduction to the topic. It introduces the world of [probabilistic programming](https://www.cs.cornell.edu/Courses/cs4110/2016fa/lectures/lecture33.html){target="_blank"}, in particular [Stan](http://mc-stan.org/){target="_blank"}, which can be used in both `R` and Python.
 
 ## High Performance Computing
 
-Often `R` will be called a "slow" language, for two reasons. One, because many do not understand `R`. Two, because sometimes it really is. Luckily, it is easy to extend `R` via the [`Rcpp` package](http://www.rcpp.org/) to allow for faster code. Many modern `R` packages utilize `Rcpp` to achieve better performance.
+Often `R` will be called a "slow" language, for two reasons. One, because many do not understand `R`. Two, because sometimes it really is. Luckily, it is easy to extend `R` via the [`Rcpp` package](http://www.rcpp.org/){target="_blank"} to allow for faster code. Many modern `R` packages utilize `Rcpp` to achieve better performance.
 
 ## Further `R` Resources
 
-Also, don't forget that previously in this book we have outlined a large number of [`R` resources](http://daviddalpiaz.github.io/appliedstats/introduction-to-r.html#r-resources). Now that you've gotten started with `R` many of these will be much more useful.
+Also, don't forget that previously in this book we have outlined a large number of [`R` resources](http://daviddalpiaz.github.io/appliedstats/introduction-to-r.html#r-resources){target="_blank"}. Now that you've gotten started with `R` many of these will be much more useful.
 
 If any of these topics interest you, and you would like more information, please don't hesitate to start a discussion on the forums!
 

--- a/data-and-programming.Rmd
+++ b/data-and-programming.Rmd
@@ -45,9 +45,9 @@ x = c(1, 3, 5, 7, 8, 9)
 x
 ```
 
-As an aside, there is a long history of the assignment operator in `R`, partially due to the keys available on the [keyboards of the creators of the `S` language.](https://twitter.com/kwbroman/status/747829864091127809) (Which preceded `R`.) For simplicity we will use `=`, but know that often you will see `<-` as the assignment operator. 
+As an aside, there is a long history of the assignment operator in `R`, partially due to the keys available on the [keyboards of the creators of the `S` language.](https://twitter.com/kwbroman/status/747829864091127809){target="_blank"} (Which preceded `R`.) For simplicity we will use `=`, but know that often you will see `<-` as the assignment operator. 
 
-The pros and cons of these two are well beyond the scope of this book, but know that for our purposes you will have no issue if you simply use `=`. If you are interested in the weird cases where the difference matters, check out [The R Inferno](http://www.burns-stat.com/documents/books/the-r-inferno/).
+The pros and cons of these two are well beyond the scope of this book, but know that for our purposes you will have no issue if you simply use `=`. If you are interested in the weird cases where the difference matters, check out [The R Inferno](http://www.burns-stat.com/documents/books/the-r-inferno/){target="_blank"}.
 
 If you wish to use `<-`, you will still need to use `=`, however only for argument passing. Some users like to keep assignment (`<-`) and argument passing (`=`) separate. No matter what you choose, the more important thing is that you **stay consistent**. Also, if working on a larger collaborative project, you should use whatever style is already in place.
 
@@ -572,7 +572,7 @@ The `data.frame()` function above is one way to create a data frame. We can also
 write.csv(example_data, "data/example-data.csv", row.names = FALSE)
 ```
 
-[The example data above can also be found here as a .csv file.](data/example-data.csv) To read this data into `R`, we would use the `read_csv()` function from the `readr` package. Note that `R` has a built in function `read.csv()` that operates very similarly. The `readr` function `read_csv()` has a number of advantages. For example, it is much faster reading larger data. [It also uses the `tibble` package to read the data as a tibble.](https://cran.r-project.org/web/packages/tibble/vignettes/tibble.html)
+[The example data above can also be found here as a .csv file.](data/example-data.csv) To read this data into `R`, we would use the `read_csv()` function from the `readr` package. Note that `R` has a built in function `read.csv()` that operates very similarly. The `readr` function `read_csv()` has a number of advantages. For example, it is much faster reading larger data. [It also uses the `tibble` package to read the data as a tibble.](https://cran.r-project.org/web/packages/tibble/vignettes/tibble.html){target="_blank"}
 
 ```{r, message = FALSE, warning = FALSE}
 library(readr)

--- a/diagnostics.Rmd
+++ b/diagnostics.Rmd
@@ -228,7 +228,7 @@ This time on the fitted versus residuals plot, for any fitted value, the spread 
 
 Constant variance is often called **homoscedasticity**. Conversely, non-constant variance is called **heteroscedasticity**. We've seen how we can use a fitted versus residuals plot to look for these attributes.
 
-While a fitted versus residuals plot can give us an idea about homoscedasticity, sometimes we would prefer a more formal test. There are many tests for constant variance, but here we will present one, the [**Breusch-Pagan Test**](https://en.wikipedia.org/wiki/Breusch%E2%80%93Pagan_test). The exact details of the test will omitted here, but importantly the null and alternative can be considered to be,
+While a fitted versus residuals plot can give us an idea about homoscedasticity, sometimes we would prefer a more formal test. There are many tests for constant variance, but here we will present one, the [**Breusch-Pagan Test**](https://en.wikipedia.org/wiki/Breusch%E2%80%93Pagan_test){target="_blank"}. The exact details of the test will omitted here, but importantly the null and alternative can be considered to be,
 
 - $H_0$: Homoscedasticity. The errors have constant variance about the true model.
 - $H_1$: Heteroscedasticity.  The errors have non-constant variance about the true model.
@@ -309,7 +309,7 @@ In short, if the points of the plot do not closely follow a straight line, this 
 
 The calculations required to create the plot vary depending on the implementation, but essentially the $y$-axis is the sorted data (observed, or sample quantiles), and the $x$-axis is the values we would expect if the data did come from a normal distribution (theoretical quantiles).
 
-The [Wikipedia page for Normal probability plots](http://en.wikipedia.org/wiki/Normal_probability_plot) gives details on how this is implemented in `R` if you are interested.
+The [Wikipedia page for Normal probability plots](http://en.wikipedia.org/wiki/Normal_probability_plot){target="_blank"} gives details on how this is implemented in `R` if you are interested.
 
 Also, to get a better idea of how Q-Q plots work, here is a quick function which creates a Q-Q plot:
 
@@ -428,7 +428,7 @@ shapiro.test(rexp(25))
 
 This gives us the value of the test statistic and its p-value. The null hypothesis assumes the data were sampled from a normal distribution, thus a small p-value indicates we believe there is only a small probability the data could have been sampled from a normal distribution.
 
-For details, see: [Wikipedia: Shapiro–Wilk test.](https://en.wikipedia.org/wiki/Shapiro-Wilk_test)
+For details, see: [Wikipedia: Shapiro–Wilk test.](https://en.wikipedia.org/wiki/Shapiro-Wilk_test){target="_blank"}
 
 In the above examples, we see we fail to reject for the data sampled from normal, and reject on the non-normal data, for any reasonable $\alpha$.
 
@@ -450,7 +450,7 @@ shapiro.test(resid(fit_3))
 
 In addition to checking the assumptions of regression, we also look for any "unusual observations" in the data. Often a small number of data points can have an extremely large influence on a regression, sometimes so much so that the regression assumptions are violated as a result of these points.
 
-The following three plots are inspired by an example from [Linear Models with R](http://www.maths.bath.ac.uk/~jjf23/LMR/).
+The following three plots are inspired by an example from [Linear Models with R](http://www.maths.bath.ac.uk/~jjf23/LMR/){target="_blank"}.
 
 ```{r unusual_obs_plot, fig.height = 5, fig.width = 15}
 par(mfrow = c(1, 3))

--- a/index.Rmd
+++ b/index.Rmd
@@ -1,6 +1,5 @@
 --- 
 title: "Applied Statistics with `R`"
-author: "[David Dalpiaz](https://daviddalpiaz.com/)"
 date: "`r Sys.Date()`"
 github-repo: daviddalpiaz/appliedstats
 url: 'https\://daviddalpiaz.github.io/appliedstats/'
@@ -36,9 +35,9 @@ Welcome to Applied Statistics with `R`!
 
 This book was originally (and currently) designed for use with STAT 420, Methods of Applied Statistics, at the University of Illinois at Urbana-Champaign. It may certainly be used elsewhere, but any references to "this course" in this book specifically refer to STAT 420.
 
-This book is under active development. When possible, it would be best to always access the text online to be sure you are using the most up-to-date version. Also, the html version provides additional features such as changing text size, font, and colors. If you are in need of a local copy, a [**pdf version** is continuously maintained](http://daviddalpiaz.github.io/appliedstats/applied_statistics.pdf).
+This book is under active development. When possible, it would be best to always access the text online to be sure you are using the most up-to-date version. Also, the html version provides additional features such as changing text size, font, and colors. If you are in need of a local copy, a [**pdf version** is continuously maintained](http://daviddalpiaz.github.io/appliedstats/applied_statistics.pdf){target="_blank"}.
 
-Since this book is under active development you may encounter errors ranging from typos, to broken code, to poorly explained topics. If you do, please let us know! Simply send an email and we will make the changes as soon as possible. (`dalpiaz2 AT illinois DOT edu`) Or, if you know RMarkdown and are familiar with GitHub, [make a pull request and fix an issue yourself!](https://github.com/daviddalpiaz/appliedstats) This process is partially automated by the edit button in the top-left corner of the html version. If your suggestion or fix becomes part of the book, you will be added to the list at the end of this chapter. We'll also link to your GitHub account, or personal website upon request.
+Since this book is under active development you may encounter errors ranging from typos, to broken code, to poorly explained topics. If you do, please let us know! Simply send an email and we will make the changes as soon as possible. (`dalpiaz2 AT illinois DOT edu`) Or, if you know RMarkdown and are familiar with GitHub, [make a pull request and fix an issue yourself!](https://github.com/daviddalpiaz/appliedstats){target="_blank"} This process is partially automated by the edit button in the top-left corner of the html version. If your suggestion or fix becomes part of the book, you will be added to the list at the end of this chapter. We'll also link to your GitHub account, or personal website upon request.
 
 This text uses MathJax to render mathematical notation for the web. Occasionally, but rarely, a JavaScript error will prevent MathJax from rendering correctly. In this case, you will see the "code" instead of the expected mathematical equations. From experience, this is almost always fixed by simply refreshing the page. You'll also notice that if you right-click any equation you can obtain the MathML Code (for copying into Microsoft Word) or the TeX command used to generate the equation.
 
@@ -72,25 +71,25 @@ Material in this book was heavily influenced by:
 
 - Alex Stepanov
     - Longtime instructor of STAT 420 at the University of Illinois at Urbana-Champaign. The author of this book actually took Alex's STAT 420 class many years ago! Alex provided or inspired many of the examples in the text.
-- [David Unger](http://publish.illinois.edu/dunger/)
+- [David Unger](http://publish.illinois.edu/dunger/){target="_blank"}
     - Another STAT 420 instructor at the University of Illinois at Urbana-Champaign. Co-taught with the author during the summer of 2016 while this book was first being developed. Provided endless hours of copy editing and countless suggestions.
-- [James Balamuta](http://www.thecoatlessprofessor.com/)
-    - Current graduate student at the University of Illinois at Urbana-Champaign. Provided the initial push to write this book by introducing the author to the [`bookdown`](https://bookdown.org/yihui/bookdown/) package in `R`. Also a frequent contributor via GitHub.
+- [James Balamuta](http://www.thecoatlessprofessor.com/){target="_blank"}
+    - Current graduate student at the University of Illinois at Urbana-Champaign. Provided the initial push to write this book by introducing the author to the [`bookdown`](https://bookdown.org/yihui/bookdown/){target="_blank"} package in `R`. Also a frequent contributor via GitHub.
 
 Your name could be here! Suggest an edit! Correct a typo! If you submit a correction and would like to be listed below, please provide your name as you would like it to appear, as well as a link to a GitHub, LinkedIn, or personal website.
 
-- [Daniel McQuillan](https://github.com/dmcquillan314)
-- [Mason Rubenstein](https://github.com/mruben09)
-- [Yuhang Wang](https://github.com/yuhangwang)
+- [Daniel McQuillan](https://github.com/dmcquillan314){target="_blank"}
+- [Mason Rubenstein](https://github.com/mruben09){target="_blank"}
+- [Yuhang Wang](https://github.com/yuhangwang){target="_blank"}
 - Zhao Liu
-- [Jinfeng Xiao](https://github.com/JinfengXiao)
-- [Somu Palaniappan](https://www.linkedin.com/in/somupalaniappan)
-- [Michael Hung-Yiu Chan](https://www.linkedin.com/in/michaelchan2newyork)
-- [Eloise Rosen](https://github.com/EloiseRosen)
-- [Kiomars Nassiri](https://www.linkedin.com/in/kiomars-nassiri-kahnamooee/)
-- [Jeff Gerlach](https://github.com/jeffgerlach)
-- [Brandon Ching](https://github.com/linuxdream)
-- [Ray Fix](https://github.com/rayfix)
+- [Jinfeng Xiao](https://github.com/JinfengXiao){target="_blank"}
+- [Somu Palaniappan](https://www.linkedin.com/in/somupalaniappan){target="_blank"}
+- [Michael Hung-Yiu Chan](https://www.linkedin.com/in/michaelchan2newyork){target="_blank"}
+- [Eloise Rosen](https://github.com/EloiseRosen){target="_blank"}
+- [Kiomars Nassiri](https://www.linkedin.com/in/kiomars-nassiri-kahnamooee/){target="_blank"}
+- [Jeff Gerlach](https://github.com/jeffgerlach){target="_blank"}
+- [Brandon Ching](https://github.com/linuxdream){target="_blank"}
+- [Ray Fix](https://github.com/rayfix){target="_blank"}
 
 ## License
 

--- a/logistic.Rmd
+++ b/logistic.Rmd
@@ -23,7 +23,7 @@ Now we'll allow for two modifications of this situation, which will let us use l
 
 In *general*, a generalized linear model has three parts:
 
-- A **distribution** of the response conditioned on the predictors. (Technically this distribution needs to be from the [exponential family](https://en.wikipedia.org/wiki/Exponential_family) of distributions.)
+- A **distribution** of the response conditioned on the predictors. (Technically this distribution needs to be from the [exponential family](https://en.wikipedia.org/wiki/Exponential_family){target="_blank"} of distributions.)
 - A **linear combination** of the $p - 1$ predictors, $\beta_0 + \beta_1 x_1 + \beta_2 x_2 + \ldots  + \beta_{p - 1} x_{p - 1}$, which we write as $\eta({\bf x})$. That is,  
 
 $$\eta({\bf x}) = \beta_0 + \beta_1 x_1 + \beta_2 x_2 + \ldots  + \beta_{p - 1} x_{p - 1}$$
@@ -97,13 +97,13 @@ $$
 \frac{p({\bf x})}{1 - p({\bf x})} = \frac{P[Y = 1 \mid {\bf X} = {\bf x}]}{P[Y = 0 \mid {\bf X} = {\bf x}]}
 $$
 
-Essentially, the log odds are the [logit](https://en.wikipedia.org/wiki/Logit) transform applied to $p({\bf x})$.
+Essentially, the log odds are the [logit](https://en.wikipedia.org/wiki/Logit){target="_blank"} transform applied to $p({\bf x})$.
 
 $$
 \text{logit}(x) = \log\left(\frac{x}{1 - x}\right)
 $$
 
-It will also be useful to define the inverse logit, otherwise known as the "logistic" or [sigmoid](https://en.wikipedia.org/wiki/Sigmoid_function) function.
+It will also be useful to define the inverse logit, otherwise known as the "logistic" or [sigmoid](https://en.wikipedia.org/wiki/Sigmoid_function){target="_blank"} function.
 
 $$
 \text{logit}^{-1}(x) = \frac{e^x}{1 + e^{x}} = \frac{1}{1 + e^{-x}}
@@ -198,7 +198,7 @@ This, and similar numeric issues related to estimated probabilities near 0 or 1,
 message("Warning: glm.fit: fitted probabilities numerically 0 or 1 occurred")
 ```
 
-When this happens, the model is still "fit," but there are consequences, namely, the estimated coefficients are highly suspect. This is an issue when then trying to interpret the model. When this happens, the model will often still be useful for creating a classifier, which will be discussed later. However, it is still subject to the usual evaluations for classifiers to determine how well it is performing. For details, see [Modern Applied Statistics with S-PLUS, Chapter 7](https://link.springer.com/content/pdf/10.1007/978-1-4757-2719-7_7.pdf).
+When this happens, the model is still "fit," but there are consequences, namely, the estimated coefficients are highly suspect. This is an issue when then trying to interpret the model. When this happens, the model will often still be useful for creating a classifier, which will be discussed later. However, it is still subject to the usual evaluations for classifiers to determine how well it is performing. For details, see [Modern Applied Statistics with S-PLUS, Chapter 7](https://link.springer.com/content/pdf/10.1007/978-1-4757-2719-7_7.pdf){target="_blank"}.
 
 ### Simulation Examples
 
@@ -683,7 +683,7 @@ Based on the $z$-test seen in the above summary, this interaction is significant
 
 You have probably noticed that the output from `summary()` is very similar to that of ordinary linear regression. One difference, is the "deviance" being reported. The `Null deviance` is the deviance for the null model, that is, a model with no predictors. The `Residual deviance` is the deviance for the mode that was fit.
 
-[**Deviance**](https://en.wikipedia.org/wiki/Deviance_(statistics)) compares the model to a saturated model. (Without repeated observations, a saturated model is a model that fits perfectly, using a parameter for each observation.) Essentially, deviance is a generalized *residual sum of squared* for GLMs. Like RSS, deviance decreased as the model complexity increases.
+[**Deviance**](https://en.wikipedia.org/wiki/Deviance_(statistics){target="_blank"}) compares the model to a saturated model. (Without repeated observations, a saturated model is a model that fits perfectly, using a parameter for each observation.) Essentially, deviance is a generalized *residual sum of squared* for GLMs. Like RSS, deviance decreased as the model complexity increases.
 
 ```{r}
 deviance(chd_mod_ldl)
@@ -747,7 +747,7 @@ data("spam")
 tibble::as.tibble(spam)
 ```
 
-This dataset, created in the late 1990s at Hewlett-Packard Labs, contains 4601 emails, of which 1813 are considered spam. The remaining are not spam. (Which for simplicity, we might call, ham.) Additional details can be obtained by using `?spam` of by visiting the [UCI Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets/spambase). 
+This dataset, created in the late 1990s at Hewlett-Packard Labs, contains 4601 emails, of which 1813 are considered spam. The remaining are not spam. (Which for simplicity, we might call, ham.) Additional details can be obtained by using `?spam` of by visiting the [UCI Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets/spambase){target="_blank"}. 
 
 The response variable, `type`, is a **factor** with levels that label each email as `spam` or `nonspam`. When fitting models, `nonspam` will be the reference level, $Y = 0$, as it comes first alphabetically.
 
@@ -910,7 +910,7 @@ This seems like a decent classifier...
 
 However, are all errors created equal? In this case, absolutely note. The 137 non-spam emails that were marked as spam (false positives) are a problem. We can't allow important information, say, a job offer, miss our inbox and get sent to the spam folder. On the other hand, the 161 spam email that would make it to an inbox (false negatives) are easily dealt with, just delete them.
 
-Instead of simply evaluating a classifier based on its misclassification rate (or accuracy), we'll define two additional metrics, sensitivity and specificity. Note that this are simply two of many more metrics that can be considered. The [Wikipedia page for sensitivity_and_specificity](https://en.wikipedia.org/wiki/Sensitivity_and_specificity) details a large number of metrics that can be derived form a confusion matrix.
+Instead of simply evaluating a classifier based on its misclassification rate (or accuracy), we'll define two additional metrics, sensitivity and specificity. Note that this are simply two of many more metrics that can be considered. The [Wikipedia page for sensitivity_and_specificity](https://en.wikipedia.org/wiki/Sensitivity_and_specificity){target="_blank"} details a large number of metrics that can be derived form a confusion matrix.
 
 **Sensitivity** is essentially the true positive rate. So when sensitivity if high, the number of false negatives is low.
 
@@ -997,6 +997,6 @@ get_spec(conf_mat_90)
 
 While this is far fewer false positives, is it acceptable though? Still probably not. Also, don't forget, this would actually be a terrible spam detector today since this is based on data from a very different era of the internet, for a very specific set of people. Spam has changed a lot since 90s! (Ironically, machine learning is probably partially to blame.)
 
-This chapter has provided a rather quick introduction to classification, and thus, machine learning. For a more complete coverage of machine learning, [An Introduction to Statistical Learning](http://www-bcf.usc.edu/~gareth/ISL/) is a highly recommended resource. Additionally, [`R` for Statistical Learning](https://daviddalpiaz.github.io/r4sl/) has been written as a supplement which provides additional detail on how to perform these methods using `R`. The [classification](https://daviddalpiaz.github.io/r4sl/classification-overview.html) and [logistic regression](https://daviddalpiaz.github.io/r4sl/logistic-regression.html) chapters might be useful.
+This chapter has provided a rather quick introduction to classification, and thus, machine learning. For a more complete coverage of machine learning, [An Introduction to Statistical Learning](http://www-bcf.usc.edu/~gareth/ISL/){target="_blank"} is a highly recommended resource. Additionally, [`R` for Statistical Learning](https://daviddalpiaz.github.io/r4sl/){target="_blank"} has been written as a supplement which provides additional detail on how to perform these methods using `R`. The [classification](https://daviddalpiaz.github.io/r4sl/classification-overview.html){target="_blank"} and [logistic regression](https://daviddalpiaz.github.io/r4sl/logistic-regression.html){target="_blank"} chapters might be useful.
 
-We should note that the code to perform classification using logistic regression is presented in a way that illustrates the concepts to the reader. In practice, you may to prefer to use a more general machine learning pipeline such as [`caret`](http://topepo.github.io/caret/index.html) in `R`. This will streamline processes for creating predictions and generating evaluation metrics.
+We should note that the code to perform classification using logistic regression is presented in a way that illustrates the concepts to the reader. In practice, you may to prefer to use a more general machine learning pipeline such as [`caret`](http://topepo.github.io/caret/index.html){target="_blank"} in `R`. This will streamline processes for creating predictions and generating evaluation metrics.

--- a/mlr.Rmd
+++ b/mlr.Rmd
@@ -51,7 +51,7 @@ write.csv(autompg, "data/autompg.csv")
 ```
 
 
-We will once again discuss a dataset with information about cars. [This dataset](http://archive.ics.uci.edu/ml/machine-learning-databases/auto-mpg/auto-mpg.data), which can be found at the [UCI Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets/Auto+MPG) contains a response variable `mpg` which stores the city fuel efficiency of cars, as well as several predictor variables for the attributes of the vehicles. We load the data, and perform some basic tidying before moving on to analysis.
+We will once again discuss a dataset with information about cars. [This dataset](http://archive.ics.uci.edu/ml/machine-learning-databases/auto-mpg/auto-mpg.data){target="_blank"}, which can be found at the [UCI Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets/Auto+MPG){target="_blank"} contains a response variable `mpg` which stores the city fuel efficiency of cars, as well as several predictor variables for the attributes of the vehicles. We load the data, and perform some basic tidying before moving on to analysis.
 
 For now we will focus on using two variables, `wt` and `year`, as predictor variables. That is, we would like to model the fuel efficiency (`mpg`) of a car as a function of its weight (`wt`) and model year (`year`). To do so, we will define the following linear model,
 

--- a/model_building.Rmd
+++ b/model_building.Rmd
@@ -235,7 +235,7 @@ autompg = subset(autompg, select = c("mpg", "cyl", "disp", "hp", "wt", "acc", "y
 autompg$hp = as.numeric(autompg$hp)
 ```
 
-A word of caution when using a model to *explain* a relationship. There are two terms often used to describe a relationship between two variables: *causation* and *correlation*. [Correlation](https://xkcd.com/552/) is often also referred to as association.
+A word of caution when using a model to *explain* a relationship. There are two terms often used to describe a relationship between two variables: *causation* and *correlation*. [Correlation](https://xkcd.com/552/){target="_blank"} is often also referred to as association.
 
 Just because two variables are correlated does not necessarily mean that one causes the other. For example, consider modeling `mpg` as only a function of `hp`.
 
@@ -247,7 +247,7 @@ Does an increase in horsepower cause a drop in fuel efficiency? Or, perhaps the 
 
 The issue here is that we have **observational** data. With observational data, we can only detect *associations*. To speak with confidence about *causality*, we would need to run **experiments**. Often, this is decision is made for us, before we ever see data, so we can only modify our interpretation.
 
-This is a concept that you should encounter often in your statistics education. For some further reading, and some related fallacies, see: [Wikipedia: Correlation does not imply causation](https://en.wikipedia.org/wiki/Correlation_does_not_imply_causation).
+This is a concept that you should encounter often in your statistics education. For some further reading, and some related fallacies, see: [Wikipedia: Correlation does not imply causation](https://en.wikipedia.org/wiki/Correlation_does_not_imply_causation){target="_blank"}.
 
 We'll discuss this further when we discuss experimental design and traditional ANOVA techniques. (All of which has recently been re-branded as A/B testing.)
 

--- a/r-intro.Rmd
+++ b/r-intro.Rmd
@@ -4,9 +4,9 @@
 
 `R` is both a programming language and software environment for statistical computing, which is *free* and *open-source*. To get started, you will need to install two pieces of software:
 
-- [`R`, the actual programming language.](http://cran.r-project.org/)
+- [`R`, the actual programming language.](http://cran.r-project.org/){target="_blank"}
     - Chose your operating system, and select the most recent version, `r paste0(version$major, "." ,version$minor)`.
-- [RStudio, an excellent IDE for working with `R`.](http://www.rstudio.com/)
+- [RStudio, an excellent IDE for working with `R`.](http://www.rstudio.com/){target="_blank"}
     - Note, you must have `R` installed to use RStudio. RStudio is simply an interface used to interact with `R`.
 
 The popularity of `R` is on the rise, and everyday it becomes a better tool for statistical analysis. It even generated this book! (A skill you will learn in this course.) There are many good resources for learning `R`. 
@@ -22,12 +22,12 @@ RStudio has a large number of useful keyboard shortcuts. A list of these can be 
 - On Windows: `Alt` + `Shift` + `K`
 - On Mac:  `Option` + `Shift` + `K`
 
-The RStudio team has developed [a number of "cheatsheets"](https://www.rstudio.com/resources/cheatsheets/) for working with both `R` and RStudio. [This particular cheatseet for Base `R`](http://www.rstudio.com/wp-content/uploads/2016/05/base-r.pdf) will summarize many of the concepts in this document.
+The RStudio team has developed [a number of "cheatsheets"](https://www.rstudio.com/resources/cheatsheets/){target="_blank"} for working with both `R` and RStudio. [This particular cheatseet for Base `R`](http://www.rstudio.com/wp-content/uploads/2016/05/base-r.pdf){target="_blank"} will summarize many of the concepts in this document.
 
 When programming, it is often a good practice to follow a style guide. (Where do spaces go? Tabs or spaces? Underscores or CamelCase when naming variables?) No style guide is "correct" but it helps to be aware of what others do. The more import thing is to be consistent within your own code.
 
-- [Hadley Wickham Style Guide](http://adv-r.had.co.nz/Style.html) from [Advanced `R`](http://adv-r.had.co.nz/)
-- [Google Style Guide](https://google.github.io/styleguide/Rguide.xml)
+- [Hadley Wickham Style Guide](http://adv-r.had.co.nz/Style.html){target="_blank"} from [Advanced `R`](http://adv-r.had.co.nz/){target="_blank"}
+- [Google Style Guide](https://google.github.io/styleguide/Rguide.xml){target="_blank"}
 
 For this course, our main deviation from these two guides is the use of `=` in place of `<-`. (More on that later.)
 
@@ -89,7 +89,7 @@ In using `R` as a calculator, we have seen a number of functions: `sqrt()`, `exp
 ?lm
 ```
 
-Frequently one of the most difficult things to do when learning `R` is asking for help. First, you need to decide to ask for help, then you need to know *how* to ask for help. Your very first line of defense should be to Google your error message or a short description of your issue. (The ability to solve problems using this method is quickly becoming an extremely valuable skill.) If that fails, and it eventually will, you should ask for help. There are a number of things you should include when emailing an instructor, or posting to a help website such as [Stack Exchange](http://stats.stackexchange.com/).
+Frequently one of the most difficult things to do when learning `R` is asking for help. First, you need to decide to ask for help, then you need to know *how* to ask for help. Your very first line of defense should be to Google your error message or a short description of your issue. (The ability to solve problems using this method is quickly becoming an extremely valuable skill.) If that fails, and it eventually will, you should ask for help. There are a number of things you should include when emailing an instructor, or posting to a help website such as [Stack Exchange](http://stats.stackexchange.com/){target="_blank"}.
 
 - Describe what you expect the code to do.
 - State the end goal you are trying to achieve. (Sometimes what you expect the code to do, is not what you want to actually do.)

--- a/r-resources.Rmd
+++ b/r-resources.Rmd
@@ -4,50 +4,50 @@ So far, we have seen a lot of `R`, and a lot of `R` quickly. Again, the precedin
 
 ## Beginner Tutorials and References
 
-- [Try `R`](http://tryr.codeschool.com/) from Code School.
+- [Try `R`](http://tryr.codeschool.com/){target="_blank"} from Code School.
     - An interactive introduction to the basics of `R`. Useful for getting up to speed on `R`'s syntax.
-- [Quick-R](http://www.statmethods.net/) by Robert Kabacoff.
+- [Quick-R](http://www.statmethods.net/){target="_blank"} by Robert Kabacoff.
     - A good reference for `R` basics.
-- [`R` Tutorial](http://www.r-tutor.com/) by Chi Yau.
+- [`R` Tutorial](http://www.r-tutor.com/){target="_blank"} by Chi Yau.
     - A combination reference and tutorial for `R` basics.
-- [`R` Programming for Data Science](https://bookdown.org/rdpeng/rprogdatascience/) by Roger Peng
+- [`R` Programming for Data Science](https://bookdown.org/rdpeng/rprogdatascience/){target="_blank"} by Roger Peng
     - A great text for `R` programming beginners. Discusses `R` from the ground up, highlighting programming details we might not discuss.
 
 ## Intermediate References
 
-- [`R` for Data Science](http://r4ds.had.co.nz/) by Hadley Wickham and Garrett Grolemund.
-    - Similar to Advanced `R`, but focuses more on data analysis, while still introducing programming concepts. Especially useful for working in the [tidyverse](http://tidyverse.org/). 
-- [The Art of `R` Programming](https://www.nostarch.com/artofr.htm) by Norman Matloff.
-    - Gentle introduction to the programming side of `R`. (Whereas we will focus more on the data analysis side.) A [free electronic version](http://vufind.carli.illinois.edu/vf-uiu/Record/uiu_6955421) is available through the Illinois library.
+- [`R` for Data Science](http://r4ds.had.co.nz/){target="_blank"} by Hadley Wickham and Garrett Grolemund.
+    - Similar to Advanced `R`, but focuses more on data analysis, while still introducing programming concepts. Especially useful for working in the [tidyverse](http://tidyverse.org/){target="_blank"}. 
+- [The Art of `R` Programming](https://www.nostarch.com/artofr.htm){target="_blank"} by Norman Matloff.
+    - Gentle introduction to the programming side of `R`. (Whereas we will focus more on the data analysis side.) A [free electronic version](http://vufind.carli.illinois.edu/vf-uiu/Record/uiu_6955421){target="_blank"} is available through the Illinois library.
 
 ## Advanced References
 
-- [Advanced `R`](http://adv-r.had.co.nz/) by Hadley Wickham.
+- [Advanced `R`](http://adv-r.had.co.nz/){target="_blank"} by Hadley Wickham.
     - From the author of several extremely popular `R` packages. Good follow-up to The Art of `R` Programming. (And more up-to-date material.)
-- [The `R` Inferno](http://www.burns-stat.com/documents/books/the-r-inferno/) by Patrick Burns.
+- [The `R` Inferno](http://www.burns-stat.com/documents/books/the-r-inferno/){target="_blank"} by Patrick Burns.
     - Likens learning the tricks of `R` to descending through the levels of hell. Very advanced material, but may be important if `R` becomes a part of your everyday toolkit.
-- [Efficient `R` Programming](https://csgillespie.github.io/efficientR/) by Colin Gillespie and Robin Lovelace
+- [Efficient `R` Programming](https://csgillespie.github.io/efficientR/){target="_blank"} by Colin Gillespie and Robin Lovelace
     - Discusses both efficient `R` programs, as well as programming in `R` efficiently.
 
 ## Quick Comparisons to Other Languages
 
 Those who are familiar with other languages may find the following "cheatsheets" helpful for transitioning to `R`.
 
-- [MATLAB, NumPy, Julia](http://hyperpolyglot.org/numerical-analysis2#polynomials)
-- [Stata](http://dss.princeton.edu/training/RStata.pdf)
+- [MATLAB, NumPy, Julia](http://hyperpolyglot.org/numerical-analysis2#polynomials){target="_blank"}
+- [Stata](http://dss.princeton.edu/training/RStata.pdf){target="_blank"}
 - [SAS]() - Look for a resource still! Suggestions welcome.
 
 ## RStudio and RMarkdown Videos
 
 The following video playlists were made as an introduction to `R`, RStudio, and RMarkdown for STAT 420 at UIUC. If you are currently using this text for a Coursera course, you can also find updated videos there. 
 
-- [`R` and RStudio](https://www.youtube.com/playlist?list=PLBgxzZMu3GpMjYhX7jLm5B9gEV7AOOJ5w)
-- [Data in `R`](https://www.youtube.com/playlist?list=PLBgxzZMu3GpPojVSoriMTWQCUno_3hjNi)
-- [RMarkdown](https://www.youtube.com/playlist?list=PLBgxzZMu3GpNgd07DwmS-2odHtMO6MWGH)
+- [`R` and RStudio](https://www.youtube.com/playlist?list=PLBgxzZMu3GpMjYhX7jLm5B9gEV7AOOJ5w){target="_blank"}
+- [Data in `R`](https://www.youtube.com/playlist?list=PLBgxzZMu3GpPojVSoriMTWQCUno_3hjNi){target="_blank"}
+- [RMarkdown](https://www.youtube.com/playlist?list=PLBgxzZMu3GpNgd07DwmS-2odHtMO6MWGH){target="_blank"}
 
 Note that RStudio and RMarkdown are constantly receiving excellent support and updates, so these videos may already contain some outdated information.
 
-[RStudio](http://rmarkdown.rstudio.com/) provides their own [tutorial for RMarkdown](http://rmarkdown.rstudio.com/lesson-1.html). They also have an excellent [RStudio "cheatsheets"](https://www.rstudio.com/wp-content/uploads/2016/01/rstudio-IDE-cheatsheet.pdf) which visually identifies many of the features available in the IDE.
+[RStudio](http://rmarkdown.rstudio.com/){target="_blank"} provides their own [tutorial for RMarkdown](http://rmarkdown.rstudio.com/lesson-1.html){target="_blank"}. They also have an excellent [RStudio "cheatsheets"](https://www.rstudio.com/wp-content/uploads/2016/01/rstudio-IDE-cheatsheet.pdf){target="_blank"} which visually identifies many of the features available in the IDE.
 
 ## RMarkdown Template
 

--- a/selection.Rmd
+++ b/selection.Rmd
@@ -644,7 +644,7 @@ To find small and interpretable models, we would use selection criterion that *e
 
 #### Correlation and Causation
 
-A word of caution when using a model to *explain* a relationship. There are two terms often used to describe a relationship between two variables: *causation* and *correlation*. [Correlation](https://xkcd.com/552/) is often also referred to as association.
+A word of caution when using a model to *explain* a relationship. There are two terms often used to describe a relationship between two variables: *causation* and *correlation*. [Correlation](https://xkcd.com/552/){target="_blank"} is often also referred to as association.
 
 Just because two variable are correlated does not necessarily mean that one causes the other. For example, considering modeling `mpg` as only a function of `hp`.
 
@@ -656,7 +656,7 @@ Does an increase in horsepower cause a drop in fuel efficiency? Or, perhaps the 
 
 The issue here is that we have **observational** data. With observational data, we can only detect associations. To speak with confidence about causality, we would need to run **experiments**.
 
-This is a concept that you should encounter often in your statistics education. For some further reading, and some related fallacies, see: [Wikipedia: Correlation does not imply causation](https://en.wikipedia.org/wiki/Correlation_does_not_imply_causation).
+This is a concept that you should encounter often in your statistics education. For some further reading, and some related fallacies, see: [Wikipedia: Correlation does not imply causation](https://en.wikipedia.org/wiki/Correlation_does_not_imply_causation){target="_blank"}.
 
 ### Prediction
 

--- a/slr-inf.Rmd
+++ b/slr-inf.Rmd
@@ -485,7 +485,7 @@ where $t_{\alpha/2, n - 2}$ is the critical value such that $P(t_{n-2} > t_{\alp
 
 ## Hypothesis Tests
 
-> "We may speak of this hypothesis as the '[null hypothesis](https://xkcd.com/892/)', and it should be noted that the null hypothesis is never proved or established, but is possibly disproved, in the course of experimentation."
+> "We may speak of this hypothesis as the '[null hypothesis](https://xkcd.com/892/){target="_blank"}', and it should be noted that the null hypothesis is never proved or established, but is possibly disproved, in the course of experimentation."
 >
 > --- **Ronald Aylmer Fisher**
 

--- a/slr.Rmd
+++ b/slr.Rmd
@@ -170,7 +170,7 @@ $$
 
 This is visually displayed in the image below. We see that for any value $x$, the expected value of $Y$ is $\beta_0 + \beta_1 x$. At each value of $x$, $Y$ has the same variance $\sigma^2$.
 
-![Simple Linear Regression Model [Introductory Statistics (Shafer and Zhang), UC David Stat Wiki](http://statwiki.ucdavis.edu/Textbook_Maps/General_Statistics/Map%3A_Introductory_Statistics_(Shafer_and_Zhang)/10%3A_Correlation_and_Regression/10.3_Modelling_Linear_Relationships_with_Randomness_Present)](images/model.jpg)
+![Simple Linear Regression Model [Introductory Statistics (Shafer and Zhang), UC David Stat Wiki](http://statwiki.ucdavis.edu/Textbook_Maps/General_Statistics/Map%3A_Introductory_Statistics_(Shafer_and_Zhang){target="_blank"}/10%3A_Correlation_and_Regression/10.3_Modelling_Linear_Relationships_with_Randomness_Present)](images/model.jpg)
 
 Often, we directly talk about the assumptions that this model makes. They can be cleverly shortened to **LINE**.  
 
@@ -359,7 +359,7 @@ $$
 beta_0_hat + beta_1_hat * 21
 ```
 
-Lastly, we can make a prediction for the stopping distance of a car traveling at 50 miles per hour. This is considered [**extrapolation**](https://xkcd.com/605/) as 50 is not an observed value of $x$ and is outside data range. We should be less confident in predictions of this type.
+Lastly, we can make a prediction for the stopping distance of a car traveling at 50 miles per hour. This is considered [**extrapolation**](https://xkcd.com/605/){target="_blank"} as 50 is not an observed value of $x$ and is outside data range. We should be less confident in predictions of this type.
 
 ```{r}
 range(cars$speed)
@@ -1003,7 +1003,7 @@ legend("topright", c("Estimate", "Truth"), lty = c(1, 2), lwd = 2,
 
 ## History
 
-For some brief background on the history of linear regression, see ["Galton, Pearson, and the Peas: A Brief History of Linear Regression for Statistics Instructors"](http://www.amstat.org/publications/jse/v9n3/stanton.html) from the [Journal of Statistics Education](http://www.amstat.org/publications/jse/) as well as the [Wikipedia page on the history of regression analysis](https://en.wikipedia.org/wiki/Regression_analysis#History) and lastly the article for [regression to the mean](https://en.wikipedia.org/wiki/Regression_toward_the_mean) which details the origins of the term "regression."
+For some brief background on the history of linear regression, see ["Galton, Pearson, and the Peas: A Brief History of Linear Regression for Statistics Instructors"](http://www.amstat.org/publications/jse/v9n3/stanton.html){target="_blank"} from the [Journal of Statistics Education](http://www.amstat.org/publications/jse/){target="_blank"} as well as the [Wikipedia page on the history of regression analysis](https://en.wikipedia.org/wiki/Regression_analysis#History){target="_blank"} and lastly the article for [regression to the mean](https://en.wikipedia.org/wiki/Regression_toward_the_mean){target="_blank"} which details the origins of the term "regression."
 
 
 ## RMarkdown

--- a/transformations.Rmd
+++ b/transformations.Rmd
@@ -518,7 +518,7 @@ lines(xplot, predict(mark_mod_poly3, newdata = data.frame(advert = xplot)),
       col = "red", lty = 3, lwd = 3)
 ```
 
-The previous plot was made using base graphics in `R`. The next plot was made using the package [`ggplot2`](http://ggplot2.org/), an increasingly popular plotting method in `R`.
+The previous plot was made using base graphics in `R`. The next plot was made using the package [`ggplot2`](http://ggplot2.org/){target="_blank"}, an increasingly popular plotting method in `R`.
 
 ```{r}
 library(ggplot2)


### PR DESCRIPTION
Fixes #12 Link Targets

Thanks @coatless for discovering the proper markdown syntax for the fix!
Transformation done using:

```
perl -0777 -pi -e 's/\[([^\]]*)\]\((http[^\)]*)\)/[$1]($2){target="_blank"}/g' *.Rmd
```