### PR TITLE
diagnostics.Rmd : X multiplied twice by 5

### DIFF
--- a/diagnostics.Rmd
+++ b/diagnostics.Rmd
@@ -130,19 +130,19 @@ We'll now look at a number of tools for checking the assumptions of a linear mod
 
 ```{r}
 sim_1 = function(sample_size = 500) {
-  x = runif(n = sample_size) * 5
+  x = runif(n = sample_size)
   y = 3 + 5 * x + rnorm(n = sample_size, mean = 0, sd = 1)
   data.frame(x, y)
 }
 
 sim_2 = function(sample_size = 500) {
-  x = runif(n = sample_size) * 5
+  x = runif(n = sample_size)
   y = 3 + 5 * x + rnorm(n = sample_size, mean = 0, sd = x)
   data.frame(x, y)
 }
 
 sim_3 = function(sample_size = 500) {
-  x = runif(n = sample_size) * 5
+  x = runif(n = sample_size)
   y = 3 + 5 * x ^ 2 + rnorm(n = sample_size, mean = 0, sd = 5)
   data.frame(x, y)
 }


### PR DESCRIPTION
The  model is Y = 3 + 5x + eps, but in the sim function the x was multiplied by 5 twice, once in rnorm and second time while calculating Y. I removed the former one to correct.