### PR TITLE
fix some tex commands

### DIFF
--- a/logistic.Rmd
+++ b/logistic.Rmd
@@ -560,7 +560,7 @@ The predictors are various measurements for each individual, many related to hea
 We'll begin by attempting to model the probability of coronary heart disease based on low density lipoprotein cholesterol. That is, we will fit the model
 
 $$
-\log\left(\frac{P[\texttt{chd} = 1]}{1 - P[\texttt{chd} = 1]}\right) = \beta_0 + \beta_{\texttt{ldl}} \texttt{ldl}
+\log\left(\frac{P[\texttt{chd} = 1]}{1 - P[\texttt{chd} = 1]}\right) = \beta_0 + \beta_{\texttt{ldl}} x_{\texttt{ldl}}
 $$
 
 ```{r}
@@ -660,7 +660,7 @@ $$
 Then we can create an approximate $(1 - \alpha)\%$ confidence intervals for $\eta({\bf x})$ using
 
 $$
-\hat{\eta}({\bf x}) \pm z_{\alpha/2} \cdot \text{SE}[\hat{\eta}({\bf x})]] 
+\hat{\eta}({\bf x}) \pm z_{\alpha/2} \cdot \text{SE}[\hat{\eta}({\bf x})]
 $$
 
 where $z_{\alpha/2}$ is the critical value such that $P(Z > z_{\alpha/2}) = \alpha/2$.


### PR DESCRIPTION
Explanation of two modifications.

1) `x` symbol was omitted in the predictor variable `ldl`, so I just add it.

2) it is a minor issue. I just removed `]`.