### PR TITLE
Change constant value to length(x)

### DIFF
--- a/data-and-programming.Rmd
+++ b/data-and-programming.Rmd
@@ -234,12 +234,12 @@ y = 1:100
 
 ```{r}
 x + 2
-x + rep(2, 6)
+x + rep(2, length(x))
 ```
 
 ```{r}
 x > 3
-x > rep(3, 6)
+x > rep(3, length(x))
 ```
 
 ```{r}


### PR DESCRIPTION
I would argue that having length(x) instead of just constant value better explains the fact that the second parameter to rep() function must be a multiple of length of vector x.