### PR TITLE
Update to Chapter 12 - anova.Rmd

### DIFF
--- a/anova.Rmd
+++ b/anova.Rmd
@@ -198,19 +198,19 @@ We'll leave out most of the details about how the estimation is done, but we'll 
 We'll then decompose the variance, as we've seen before in regression. The **total** variation measures how much the observations vary about the overall sample mean, *ignoring the groups*.
 
 \[
-SST = \sum_{i = i}^{g} \sum_{j = 1}^{n_i} (y_{ij} - \bar{y})^2
+SST = \sum_{i = 1}^{g} \sum_{j = 1}^{n_i} (y_{ij} - \bar{y})^2
 \]
 
 The variation **between** groups looks at how far the individual sample means are from the overall sample mean.
 
 \[
-SSB = \sum_{i = i}^{g} \sum_{j = 1}^{n_i} (\bar{y}_i - \bar{y})^2 = \sum_{i = i}^{g} n_i (\bar{y}_i - \bar{y})^2
+SSB = \sum_{i = 1}^{g} \sum_{j = 1}^{n_i} (\bar{y}_i - \bar{y})^2 = \sum_{i = i}^{g} n_i (\bar{y}_i - \bar{y})^2
 \]
 
 Lastly, the **within** group variation measures how far observations are from the sample mean of its group.
 
 \[
-SSW = \sum_{i = i}^{g} \sum_{j = 1}^{n_i} (y_{ij} - \bar{y}_i)^2 = \sum_{i = i}^{g} (n_i - 1) s_{i}^{2}
+SSW = \sum_{i = 1}^{g} \sum_{j = 1}^{n_i} (y_{ij} - \bar{y}_i)^2 = \sum_{i = i}^{g} (n_i - 1) s_{i}^{2}
 \]
 
 This could also be thought of as the error sum of squares, where $y_{ij}$ is an observation and $\bar{y}_i$ is its fitted (predicted) value from the model. 


### PR DESCRIPTION
Indexing for ANOVA decomposition (SST, SSB, SSW) listed the origin of the subscript as i=i instead of i=1 in all three cases.