### PR TITLE
Fix typo in Chapter 11

### DIFF
--- a/cat-int.Rmd
+++ b/cat-int.Rmd
@@ -206,7 +206,7 @@ rownames(autompg) = paste(autompg$cyl, "cylinder", autompg$year, autompg$name)
 autompg = subset(autompg, select = c("mpg", "cyl", "disp", "hp", "wt", "acc", "year", "origin"))
 # change horsepower from character to numeric
 autompg$hp = as.numeric(autompg$hp)
-# create a dummary variable for foreign vs domestic cars. domestic = 1.
+# create a dummy variable for foreign vs domestic cars. domestic = 1.
 autompg$domestic = as.numeric(autompg$origin == 1)
 # remove 3 and 5 cylinder cars (which are very rare.)
 autompg = autompg[autompg$cyl != 5,]


### PR DESCRIPTION
There's a typo in the code to load the data from the `autompg` dataset in chapter 11.

It says "dummary", it should be "dummy".