### PR TITLE
correct minor typo in chapter 8

### DIFF
--- a/slr-inf.Rmd
+++ b/slr-inf.Rmd
@@ -287,7 +287,7 @@ for (i in 1:num_samples) {
 }
 ```
 
-Each time we simulated the data, we obtained values of the estimated coefficiets. The variables `beta_0_hats` and `beta_1_hats` now store 10,000 simulated values of $\hat{\beta}_0$ and $\hat{\beta}_1$ respectively.
+Each time we simulated the data, we obtained values of the estimated coefficients. The variables `beta_0_hats` and `beta_1_hats` now store 10,000 simulated values of $\hat{\beta}_0$ and $\hat{\beta}_1$ respectively.
 
 We first verify the distribution of $\hat{\beta}_1$.
 


### PR DESCRIPTION
Fixed typo in Chapter 8 [simulating-sampling-distributions](https://book.stat420.org/inference-for-simple-linear-regression.html#simulating-sampling-distributions)
`coefficiets` --> `coefficients`

Signed-off-by: willtsai <william.wl.tsai@gmail.com>