### PR TITLE
Update prob-and-stat.Rmd

### DIFF
--- a/prob-and-stat.Rmd
+++ b/prob-and-stat.Rmd
@@ -98,10 +98,10 @@ where $\bar{x} = \displaystyle\frac{\sum_{i=1}^{n}x_{i}}{n}$ and $s = \sqrt{\dis
 A $100(1 - \alpha)$\% confidence interval for $\mu$ is given by,
 
 \[
-\bar{x} \pm t_{n-1}(\alpha/2)\frac{s}{\sqrt{n}}
+\bar{x} \pm t_{\alpha/2, n-1}\frac{s}{\sqrt{n}}
 \]
 
-where $t_{n-1}(\alpha/2)$ is the critical value such that $P\left(t>t_{n-1}(\alpha/2)\right) = \alpha/2$ for $n-1$ degrees of freedom.
+where $t_{\alpha/2, n-1}$ is the critical value such that $P\left(t>t_{\alpha/2, n-1}\right) = \alpha/2$ for $n-1$ degrees of freedom.
 
 ### One Sample t-Test: Example
 
@@ -182,7 +182,7 @@ We are interested in the confidence interval which is stored in `conf.int`.
 capt_test_results$conf.int
 ```
 
-Let's check this interval "by hand." The one piece of information we are missing is the critical value, $t_{n-1}(\alpha/2) = t_{8}(0.025)$, which can be calculated in `R` using the `qt()` function.
+Let's check this interval "by hand." The one piece of information we are missing is the critical value, $t_{\alpha/2, n-1} = t_{8}(0.025)$, which can be calculated in `R` using the `qt()` function.
 
 ```{r}
 qt(0.975, df = 8)
@@ -191,7 +191,7 @@ qt(0.975, df = 8)
 So, the 95\% CI for the mean weight of a cereal box is calculated by plugging into the formula,
 
 \[
-\bar{x} \pm t_{n-1}(\alpha/2) \frac{s}{\sqrt{n}}
+\bar{x} \pm t_{\alpha/2, n-1} \frac{s}{\sqrt{n}}
 \]
 
 ```{r}
@@ -216,10 +216,10 @@ where $\displaystyle\bar{x}=\frac{\sum_{i=1}^{n}x_{i}}{n}$, $\displaystyle\bar{y
 A $100(1-\alpha)$\% CI for $\mu_{x}-\mu_{y}$ is given by
 
 \[
-(\bar{x} - \bar{y}) \pm t_{n+m-2}(\alpha/2) \left(s_{p}\textstyle\sqrt{\frac{1}{n}+\frac{1}{m}}\right),
+(\bar{x} - \bar{y}) \pm t_{\alpha/2, n+m-2}\left(s_{p}\textstyle\sqrt{\frac{1}{n}+\frac{1}{m}}\right),
 \]
 
-where $t_{n+m-2}(\alpha/2)$ is the critical value such that $P\left(t>t_{n+m-2}(\alpha/2)\right)=\alpha/2$.
+where $t_{\alpha/2, n+m-2}$ is the critical value such that $P\left(t>t_{\alpha/2, n+m-2}\right)=\alpha/2$.
 
 ### Two Sample t-Test: Example
 


### PR DESCRIPTION
These changes edit Chapter 5 so that the notation used there mimics the notation used in Chapters 8, Section 9.2.2,  Section 17.3.6, and perhaps elsewhere (those were the sections where I saw the alternative notation used).  Specifically, chapter 5 has \alpha/2 as an input to a function, whereas Chapters 8, section 9.2.2, and section 17.3.6 use \alpha/2 as a subscript.  The actual notation used doesn't matter so much, but it should be consistent within a single text.  So I chose to edit Chapter 5, since that seems to be the less frequently used notation.