### PR TITLE
add explanations of any and all.equal

### DIFF
--- a/data-and-programming.Rmd
+++ b/data-and-programming.Rmd
@@ -270,6 +270,24 @@ identical(x + y, rep(x, 10) + y)
 # ?all.equal
 ```
 
+```{r}
+x = c(1, 3, 5)
+y = c(1, 2, 4)
+all(x == y)
+any(x == y)
+```
+
+While `all` returns `TRUE` only when all of their arguments are `TRUE`, `any` returns `TRUE` when at least one of their arguments is `TRUE`.
+
+```{r}
+x = c(10 ^ (-8))
+y = c(10 ^ (-9))
+all(x == y)
+all.equal(x, y)
+```
+
+`all.equal` tests "near equality" with a default tolerance value around `1.5e-8` and returns `TRUE` if all of their arguments have differences smaller than the tolerance.
+
 ### Matrices
 
 `R` can also be used for **matrix** calculations. Matrices have rows and columns containing a single data type. In a matrix, the order of rows and columns is important. (This is not true of *data frames*, which we will see later.)

--- a/data-and-programming.Rmd
+++ b/data-and-programming.Rmd
@@ -273,11 +273,12 @@ identical(x + y, rep(x, 10) + y)
 ```{r}
 x = c(1, 3, 5)
 y = c(1, 2, 4)
+x == y
 all(x == y)
 any(x == y)
 ```
 
-While `all` returns `TRUE` only when all of their arguments are `TRUE`, `any` returns `TRUE` when at least one of their arguments is `TRUE`.
+While `all` returns `TRUE` only when all of its arguments are `TRUE`, `any` returns `TRUE` when at least one of its arguments is `TRUE`.
 
 ```{r}
 x = c(10 ^ (-8))
@@ -286,7 +287,7 @@ all(x == y)
 all.equal(x, y)
 ```
 
-`all.equal` tests "near equality" with a default tolerance value around `1.5e-8` and returns `TRUE` if all of their arguments have differences smaller than the tolerance.
+The `all.equal` function tests "near equality" with a default tolerance value around `1.5e-8` and returns `TRUE` if all of its arguments have differences smaller than the tolerance.
 
 ### Matrices
 


### PR DESCRIPTION
There are no explanations of `any` and `all.equal` even though they are referred to here.
https://github.com/daviddalpiaz/appliedstats/blob/53b7a49e71120ddb86aab23290ab5cbd2c1919f8/data-and-programming.Rmd#L268-L271

So I added some explanations. 

Although we have an brief explanation of `all.equal` later, I feel like the new explanation would be helpful.
https://github.com/daviddalpiaz/appliedstats/blob/53b7a49e71120ddb86aab23290ab5cbd2c1919f8/data-and-programming.Rmd#L371

Any feedback would be much appreciated.