### PR TITLE
updated bestglm installment

### DIFF
--- a/logistic.Rmd
+++ b/logistic.Rmd
@@ -546,11 +546,14 @@ The Likelihood-Ratio Test is actually a rather general test, however, here we ha
 
 To illustrate the use of logistic regression, we will use the `SAheart` dataset from the `bestglm` package. 
 
-```{r}
+```{r, eval = FALSE}
 # "leaps" is required for "bestglm"
 if (!require("leaps")) install.packages("leaps")
-library(leaps) 
 if (!require("bestglm")) install.packages("bestglm")
+```
+
+```{r}
+library(leaps)
 library(bestglm)
 data("SAheart")
 ```

--- a/logistic.Rmd
+++ b/logistic.Rmd
@@ -544,10 +544,13 @@ The Likelihood-Ratio Test is actually a rather general test, however, here we ha
 
 ### `SAheart` Example
 
-To illustrate the use of logistic regression, we will use the `SAheart` dataset from the `ElemStatLearn` package. 
+To illustrate the use of logistic regression, we will use the `SAheart` dataset from the `bestglm` package. 
 
 ```{r}
-# install.packages("bestglm")
+# "leaps" is required for "bestglm"
+if (!require("leaps")) install.packages("leaps")
+library(leaps) 
+if (!require("bestglm")) install.packages("bestglm")
 library(bestglm)
 data("SAheart")
 ```


### PR DESCRIPTION
aiming to solve these issues:
- Package ‘ElemStatLearn’ was removed from the CRAN repository. (Maybe just forgot to fix the text.)
- printing `## Loading required package: leaps` in the knitted textbook.