### PR TITLE
add the explanation of delta of glm()

### DIFF
--- a/logistic.Rmd
+++ b/logistic.Rmd
@@ -923,7 +923,7 @@ mean(ifelse(predict(fit_over) > 0, "spam", "nonspam") != spam_trn$type)
 
 Because of this, training data isn't useful for evaluating, as it would suggest that we should always use the largest possible model, when in reality, that model is likely overfitting. Recall, a model that is too complex will overfit. A model that is too simple will underfit. (We're looking for something in the middle.)
 
-To overcome this, we'll use cross-validation as we did with ordinary linear regression, but this time we'll cross-validate the misclassification rate. To do so, we'll use the `cv.glm()` function from the `boot` library. It takes arguments for the data (in this case training), a model fit via `glm()`, and `K`, the number of folds. See `?cv.glm` for details.
+To overcome this, we'll use cross-validation as we did with ordinary linear regression, but this time we'll cross-validate the misclassification rate. To do so, we'll use the `cv.glm()` function from the `boot` library. It takes arguments for the data (in this case training), a model fit via `glm()`, and `K`, the number of folds. It returns `delta`, a vector of the average mean-squared error (MSE) and the bias-corrected MSE. See `?cv.glm` for details.
 
 Previously, for cross-validating RMSE in ordinary linear regression, we used LOOCV. We certainly could do that here. However, with logistic regression, we no longer have the clever trick that would allow us to obtain a LOOCV metric without needing to fit the model $n$ times. So instead, we'll use 5-fold cross-validation. (5 and 10 fold are the most common in practice.) Instead of leaving a single observation out repeatedly, we'll leave out a fifth of the data.
 


### PR DESCRIPTION
I think we should explicitly explain `delta`, one of the return values of `cv.glm()`, since we use it in the textbook, e.g.,

```
cv.glm(spam_trn, fit_caps, K = 5)$delta[1]
```